### PR TITLE
Enable syntax-based folding of transactions

### DIFF
--- a/ftplugin/beancount.vim
+++ b/ftplugin/beancount.vim
@@ -7,7 +7,7 @@ endif
 let b:did_ftplugin = 1
 let b:undo_ftplugin = "setlocal foldmethod< comments< commentstring<"
 
-setl foldmethod=marker
+setl foldmethod=syntax
 setl comments=b:;
 setl commentstring=;%s
 

--- a/syntax/beancount.vim
+++ b/syntax/beancount.vim
@@ -49,7 +49,7 @@ syn region beanPad matchgroup=beanKeyword start="^pad" end="$" contained
             \ contains=beanAccount,beanComment
 
 syn region beanTxn matchgroup=beanKeyword start="\v(txn)?\s+[*!]" skip="^\s"
-            \ end="^" contains=beanString,beanPost,beanComment,beanTag,beanLink,beanMeta contained
+            \ end="^" contains=beanString,beanPost,beanComment,beanTag,beanLink,beanMeta contained fold
 syn region beanPost start="^\v\C\s+[A-Z]@=" end="$"
             \ contains=beanAccount,beanAmount,beanComment,beanCost,beanPrice
 syn region beanMeta matchgroup=beanTag start="^\v\C\s+[a-z]+:(\s|$)@=" end="$"


### PR DESCRIPTION
This is much more useful compared to using just `foldmethod=marker`, and it could be enhanced to support other multi-line items in the future.