### PR TITLE
Follow include statements when completing accounts

### DIFF
--- a/autoload/beancount.vim
+++ b/autoload/beancount.vim
@@ -48,19 +48,21 @@ function! beancount#complete_account(findstart, base)
         endif
     endif
 
-    if exists('b:beancount_root')
-        let l:root = b:beancount_root
-    else
-        let l:root = expand('%')
+    if !exists('b:beancount_accounts')
+        if exists('b:beancount_root')
+            let l:root = b:beancount_root
+        else
+            let l:root = expand('%')
+        endif
+        let b:beancount_accounts = beancount#find_accounts(l:root)
     endif
-    let l:accounts = beancount#find_accounts(l:root)
     let l:pattern = '^\V' . substitute(a:base, ":", '\\S\\*:\\S\\*', "g")
     let l:matches = []
     let l:index = -1
     while 1
-        let l:index = match(l:accounts, l:pattern, l:index + 1)
+        let l:index = match(b:beancount_accounts, l:pattern, l:index + 1)
         if l:index == -1 | break | endif
-        call add(l:matches, l:accounts[l:index])
+        call add(l:matches, b:beancount_accounts[l:index])
     endwhile
     return l:matches
 endfunction

--- a/autoload/beancount.vim
+++ b/autoload/beancount.vim
@@ -56,7 +56,7 @@ function! beancount#complete_account(findstart, base)
         endif
         let b:beancount_accounts = beancount#find_accounts(l:root)
     endif
-    let l:pattern = '^\V' . substitute(a:base, ":", '\\S\\*:\\S\\*', "g")
+    let l:pattern = '\V' . substitute(a:base, ":", '\\S\\*:\\S\\*', "g")
     let l:matches = []
     let l:index = -1
     while 1

--- a/autoload/beancount.vim
+++ b/autoload/beancount.vim
@@ -87,9 +87,7 @@ def parse_file(fh, files, accounts):
     regexes = ((RE_INCLUDE, files), (RE_ACCOUNT, accounts))
     for line in fh:
         m = RE_INCLUDE.match(line)
-        if m:
-            files.append(combine_paths(os.path.dirname(fh.name), m.group(1)))
-            vim.command('echom "{}"'.format(files))
+        if m: files.append(combine_paths(os.path.dirname(fh.name), m.group(1)))
         m = RE_ACCOUNT.match(line)
         if m: accounts.add(m.group(1))
 


### PR DESCRIPTION
Naive Python implementation of 'include' following.

Potential future improvements:

- Cache account list?  (Currently it does a full scan on every
  completion.)

- A better way to set the root file? (Currently it uses
  "b:beancount_root", falling back to the current buffer if that is
  not set.)

- Error handling? (Currently if a file cannot be opened it is silently
  skipped.)