### PR TITLE
add vim-ledger style completion as an option

### DIFF
--- a/doc/beancount.txt
+++ b/doc/beancount.txt
@@ -57,10 +57,25 @@ COMPLETION                                           *beancount-completion*
 You can complete account names using CTRL-X CTRL-O. |i_CTRL-X_CTRL-O|
 Accounts must have their `open` directive in the current file. Completion is
 always case sensitive and exact. If the base string includes colons, each
-colon-separated peice can separately match a peice of the account.
+colon-separated piece can separately match a piece of the account.
 
 For example, `Ex:Other` would complete to `Expenses:Donations:Other` or
 `Liabilities:AmericanExpress:InterestOther`.
+
+There is another mode of completion where each colon-separated piece
+has to match at the beginning of that level of the account hierarchy, e.g.
+`Ex:Oth` would match `Expenses:Other` but not `Expenses:Other:Something`
+nor one of the two examples given above.
+`Ex:Oth:` would, however, list all direct sub-accounts of `Expenses:Other`.
+To enable this mode use
+
+        let g:beancount_account_completion = 'chunks'
+
+Optionally, the list of candidates can be sorted by the number of levels
+in the account hierarchy (e.g. return 'Expenses:Other' before 'Expenses').
+This behavior can be enabled using
+
+        let g:beancount_detailed_first = 1
 
 SYNTAX                                              *beancount-syntax*
 

--- a/ftplugin/beancount.vim
+++ b/ftplugin/beancount.vim
@@ -18,6 +18,12 @@ endif
 if !exists("g:beancount_decimal_separator")
     let g:beancount_decimal_separator = "."
 endif
+if !exists('g:beancount_account_completion')
+  let g:beancount_account_completion = 'default'
+endif
+if !exists('g:beancount_detailed_first')
+  let g:beancount_detailed_first = 0
+endif
 
 command! -buffer -range AlignCommodity
             \ :call beancount#align_commodity(<line1>, <line2>)


### PR DESCRIPTION
As I'm toying around with beancount at the moment, I began to miss the colon-anchored completion implemented in vim-ledger. Feel free to propose a better name for the option (instead of `chunks`) or pick away at the implementation :)