### PR TITLE
Modify foldmethod to use a comment expression

### DIFF
--- a/ftplugin/beancount.vim
+++ b/ftplugin/beancount.vim
@@ -7,7 +7,8 @@ endif
 let b:did_ftplugin = 1
 let b:undo_ftplugin = "setlocal foldmethod< comments< commentstring<"
 
-setl foldmethod=syntax
+setl foldmethod=expr
+setl foldexpr=GetBeanCountFold(v:lnum)
 setl comments=b:;
 setl commentstring=;%s
 compiler beancount
@@ -24,6 +25,20 @@ endif
 if !exists('g:beancount_detailed_first')
   let g:beancount_detailed_first = 0
 endif
+
+function! GetBeanCountFold(lnum)
+    if getline(a:lnum) =~ '\v^;\s+\+'
+        return '>1'
+    elseif getline(a:lnum) =~ '\v^;\s+-'
+        return 1
+    elseif getline(a:lnum) =~ '\v^\d{4}-\d{2}-\d{2}' && getline(a:lnum+1) =~ '\v^\s+\S+'
+        return '>2'
+    elseif getline(a:lnum) =~ '\v^\s+\S'
+        return 2
+    endif
+
+    return -1
+endfunction
 
 command! -buffer -range AlignCommodity
             \ :call beancount#align_commodity(<line1>, <line2>)


### PR DESCRIPTION
Use "header" and "footer" comments to delineate section groupings. The
format is:

```
; +<Section>
...
; -<Section>
```
where `+<Section>` is the start of a section and `-<Section>` is the end of
the section.

The resulting format of the folds would be:
```
+-- 10 lines: +Assets/Income-------------------------------------

+-- 44 lines: +Expenses------------------------------------------
```