### PR TITLE
Improved autocomplete

### DIFF
--- a/autoload/beancount.vim
+++ b/autoload/beancount.vim
@@ -74,6 +74,14 @@ function! beancount#complete(findstart, base)
         return beancount#complete_basic(s:directives, a:base)
     endif
 
+    let l:two_tokens = searchpos('\S\+\s', "bn", line("."))[1]
+    let l:prev_token = strpart(getline("."), l:two_tokens, getpos(".")[2] - l:two_tokens)
+    " Match curriences if previous token is number
+    if l:prev_token =~ '^\d\+\([\.,]\d\+\)*'
+        call beancount#load_currencies()
+        return beancount#complete_basic(b:beancount_currencies, a:base, '')
+    endif
+
     let l:first = strpart(a:base, 0, 1)
     let l:rest = strpart(a:base, 1)
     if l:first == "#"
@@ -113,6 +121,13 @@ function! beancount#load_links()
     if !exists('b:beancount_links')
         let l:root = s:get_root()
         let b:beancount_links = beancount#find_links(l:root)
+    endif
+endfunction
+
+function! beancount#load_currencies()
+    if !exists('b:beancount_currencies')
+        let l:root = s:get_root()
+        let b:beancount_currencies = beancount#find_currencies(l:root)
     endif
 endfunction
 
@@ -207,6 +222,11 @@ endfunction
 " Get list of links.
 function! beancount#find_links(root_file)
     return beancount#query_single(a:root_file, 'select distinct links;')
+endfunction
+
+" Get list of currencies.
+function! beancount#find_currencies(root_file)
+    return beancount#query_single(a:root_file, 'select distinct currency;')
 endfunction
 
 " Call bean-doctor on the current line and dump output into a scratch buffer

--- a/autoload/beancount.vim
+++ b/autoload/beancount.vim
@@ -1,6 +1,6 @@
 " Equivalent to python's startswith
 " Matches based on user's ignorecase preference
-function! s:startswith(string,prefix)
+function! s:startswith(string, prefix)
   return strpart(a:string, 0, strlen(a:prefix)) == a:prefix
 endfunction
 
@@ -178,12 +178,13 @@ import subprocess
 import os
 
 # We intentionally want to ignore stderr so it doesn't mess up our query processing
-tagoutput = subprocess.check_output(['bean-query', vim.eval('a:root_file'), vim.eval('a:query')], stderr=open(os.devnull, 'w')).split('\n')
-tagoutput = tagoutput[3:]
+output = subprocess.check_output(['bean-query', vim.eval('a:root_file'), vim.eval('a:query')], stderr=open(os.devnull, 'w')).split('\n')
+print(output)
+output = output[2:]
 
-taglist = [y for y in (x.strip() for x in tagoutput) if y]
+result_list = [y for y in (x.strip() for x in output) if y]
 
-vim.command('return [{}]'.format(','.join(repr(x) for x in sorted(taglist))))
+vim.command('return [{}]'.format(','.join(repr(x) for x in sorted(result_list))))
 EOF
 endfunction
 

--- a/autoload/beancount.vim
+++ b/autoload/beancount.vim
@@ -90,6 +90,9 @@ function! beancount#complete(findstart, base)
     elseif l:first == "^"
         call beancount#load_links()
         return beancount#complete_basic(b:beancount_links, l:rest, '^')
+    elseif l:first == '"'
+        call beancount#load_payees()
+        return beancount#complete_basic(b:beancount_payees, l:rest, '"')
     else
         call beancount#load_accounts()
         return beancount#complete_account(a:base)
@@ -128,6 +131,13 @@ function! beancount#load_currencies()
     if !exists('b:beancount_currencies')
         let l:root = s:get_root()
         let b:beancount_currencies = beancount#find_currencies(l:root)
+    endif
+endfunction
+
+function! beancount#load_payees()
+    if !exists('b:beancount_payees')
+        let l:root = s:get_root()
+        let b:beancount_payees = beancount#find_payees(l:root)
     endif
 endfunction
 
@@ -191,6 +201,11 @@ endfunction
 " Get list of currencies.
 function! beancount#find_currencies(root_file)
     return beancount#query_single(a:root_file, 'select distinct currency;')
+endfunction
+
+" Get list of payees.
+function! beancount#find_payees(root_file)
+    return beancount#query_single(a:root_file, 'select distinct payee;')
 endfunction
 
 " Call bean-doctor on the current line and dump output into a scratch buffer

--- a/autoload/beancount.vim
+++ b/autoload/beancount.vim
@@ -53,6 +53,8 @@ function! s:sort_accounts_by_depth(name1, name2)
   return depth1 == depth2 ? 0 : depth1 > depth2 ? 1 : -1
 endfunction
 
+let s:directives = ["open", "close", "commodity", "txn", "balance", "pad", "note", "document", "price", "event", "query", "custom"]
+
 " ------------------------------
 " Completion functions
 " ------------------------------
@@ -64,6 +66,12 @@ function! beancount#complete(findstart, base)
         else
             return col
         endif
+    endif
+
+    let l:partial_line = strpart(getline("."), 0, getpos(".")[2])
+    " Match directive types
+    if l:partial_line =~# '^\d\d\d\d\(-\|/\)\d\d\1\d\d \S*$'
+        return beancount#complete_basic(s:directives, a:base)
     endif
 
     let l:first = strpart(a:base, 0, 1)

--- a/autoload/beancount.vim
+++ b/autoload/beancount.vim
@@ -172,12 +172,16 @@ function! beancount#complete_account(base)
 endfunction
 
 function! beancount#query_single(root_file, query)
-let tagoutput = system('bean-query ' . a:root_file . ' "' . a:query . '" | tail -n +3')
 python << EOF
 import vim
+import subprocess
+import os
 
-tagoutput = vim.eval("tagoutput")
-taglist = [y for y in (x.strip() for x in tagoutput.split('\n')) if y != '']
+# We intentionally want to ignore stderr so it doesn't mess up our query processing
+tagoutput = subprocess.check_output(['bean-query', vim.eval('a:root_file'), vim.eval('a:query')], stderr=open(os.devnull, 'w')).split('\n')
+tagoutput = tagoutput[3:]
+
+taglist = [y for y in (x.strip() for x in tagoutput) if y]
 
 vim.command('return [{}]'.format(','.join(repr(x) for x in sorted(taglist))))
 EOF

--- a/autoload/beancount.vim
+++ b/autoload/beancount.vim
@@ -71,7 +71,7 @@ function! beancount#complete(findstart, base)
     let l:partial_line = strpart(getline("."), 0, getpos(".")[2])
     " Match directive types
     if l:partial_line =~# '^\d\d\d\d\(-\|/\)\d\d\1\d\d \S*$'
-        return beancount#complete_basic(s:directives, a:base)
+        return beancount#complete_basic(s:directives, a:base, '')
     endif
 
     let l:two_tokens = searchpos('\S\+\s', "bn", line("."))[1]

--- a/ftplugin/beancount.vim
+++ b/ftplugin/beancount.vim
@@ -32,4 +32,4 @@ command! -buffer -range GetContext
             \ :call beancount#get_context()
 
 " Omnifunc for account completion.
-setl omnifunc=beancount#complete_account
+setl omnifunc=beancount#complete


### PR DESCRIPTION
Add support for completion of payees, directives, currency, links, and tags.

I'd like to add support for event types but I don't think bean-query has the ability to do that just yet.

My next step with improvements will be vim python3 support.  I'm a little bit excited about that because we can just use the beancount libraries instead of having to shell out to other scripts.