### PR TITLE
Fix highlight of txn directive

### DIFF
--- a/syntax/beancount.vim
+++ b/syntax/beancount.vim
@@ -51,7 +51,7 @@ syn region beanPushTag matchgroup=beanKeyword start="\v^(push|pop)tag" end="$"
 syn region beanPad matchgroup=beanKeyword start="pad" end="$" contained
             \ keepend contains=beanAccount,beanComment
 
-syn region beanTxn matchgroup=beanKeyword start="\v(txn)?\s+[*!]" skip="^\s"
+syn region beanTxn matchgroup=beanKeyword start="\v\s+(txn|[*!])" skip="^\s"
             \ end="^" keepend contained fold
             \ contains=beanString,beanPost,beanComment,beanTag,beanLink,beanMeta
 syn region beanPost start="^\v\C\s+[A-Z]@=" end="$"


### PR DESCRIPTION
Syntax highlighting doesn't work properly if I enter a transaction using `txn` directive.

See attached screenshot

![image](https://cloud.githubusercontent.com/assets/153191/18582546/07818f12-7c49-11e6-8a61-b1f178a14301.png)

Quick inspection of `syntax/beancount.vim` showed that `beanTxn` assumes that `txn` is an optional prefix for a flag, while in fact `txn` and flags (!,*) are mutually exclusive things.

Quote from Beancount Language Syntax document
> As for all the other directives, a transaction directive begins with a date in the YYYY-MM-DD format and is following by directive name, in this case, “txn”.  However, because transactions are the raison d’être for our double-entry system and as such are by far the most common type of directive that should appear in a Beancount input file, we make a special case and **allow the user to elide the “txn” keyword and just use a flag instead of it**