### PR TITLE
Fix AlignCommodity to work with balance and price

### DIFF
--- a/autoload/beancount.vim
+++ b/autoload/beancount.vim
@@ -21,7 +21,7 @@ function! beancount#align_commodity(line1, line2)
         " This matches an account name followed by a space. There may be
         " some conflicts with non-transaction syntax that I don't know about.
         " It won't match a comment or any non-indented line.
-        let end_acc = matchend(s, '^\v([-\d]+\s+(balance|price))? +\S+[^:] ')
+        let end_acc = matchend(s, '^\v([\-/[:digit:]]+\s+(balance|price))? +\S+[^:] ')
         if end_acc < 0 | continue | endif
         " Where does commodity amount begin?
         let end_space = matchend(s, '^ *', end_acc)


### PR DESCRIPTION
Closes #21 and #24. Supports dates with slash separator.

Vimscript doesn't allow to use `\d` in collections (`[]`). Instead, we have to put [`[:digit]`](http://vimdoc.sourceforge.net/htmldoc/pattern.html#[:digit:]) or `0-9`

P.S. I am planning to make slight improvements to syntax highlighting and `AlignCommodity` in the future.
P.P.S. I am really sorry I didn't send this PR at the same time as the previous one. I totally forgot about this change