### PR TITLE
Improve flag support

### DIFF
--- a/autoload/beancount.vim
+++ b/autoload/beancount.vim
@@ -18,7 +18,7 @@ function! beancount#align_commodity(line1, line2)
         " This matches an account name followed by a space. There may be
         " some conflicts with non-transaction syntax that I don't know about.
         " It won't match a comment or any non-indented line.
-        let end_acc = matchend(s, '^\v([\-/[:digit:]]+\s+(balance|price))? +\S+[^:] ')
+        let end_acc = matchend(s, '^\v(([\-/[:digit:]]+\s+(balance|price))|\s+[!&#?%PSTCURM])?\s+\S+[^:] ')
         if end_acc < 0 | continue | endif
         " Where does commodity amount begin?
         let end_space = matchend(s, '^ *', end_acc)

--- a/syntax/beancount.vim
+++ b/syntax/beancount.vim
@@ -19,7 +19,7 @@ syn match beanCurrency "\v\w+" contained
 syn match beanAccount "\v[[:alnum:]]+:[-[:alnum:]:]+" contained
 syn match beanTag "\v#[-[:alnum:]]+" contained
 syn match beanLink "\v\^\S+" contained
-
+syn match beanFlag "\v[!&#?%PSTCURM]" contained
 
 " Most directives start with a date.
 syn match beanDate "^\v\d{4}[-/]\d{2}[-/]\d{2}" skipwhite
@@ -51,11 +51,11 @@ syn region beanPushTag matchgroup=beanKeyword start="\v^(push|pop)tag" end="$"
 syn region beanPad matchgroup=beanKeyword start="pad" end="$" contained
             \ keepend contains=beanAccount,beanComment
 
-syn region beanTxn matchgroup=beanKeyword start="\v\s+(txn|[*!])" skip="^\s"
+syn region beanTxn matchgroup=beanKeyword start="\v\s+(txn|[!&#?%PSTCURM])" skip="^\s"
             \ end="^" keepend contained fold
             \ contains=beanString,beanPost,beanComment,beanTag,beanLink,beanMeta
-syn region beanPost start="^\v\C\s+[A-Z]@=" end="$"
-            \ contains=beanAccount,beanAmount,beanComment,beanCost,beanPrice
+syn region beanPost start="^\v\C\s+(([!&#?%PSTCURM]\s+)?[A-Z])@=" end="$"
+            \ contains=beanFlag,beanAccount,beanAmount,beanComment,beanCost,beanPrice
 syn region beanMeta matchgroup=beanTag start="^\v\C\s+[a-z][-_a-zA-Z0-9]*:(\s|$)@=" end="$"
 
 syn region beanCost start="{" end="}" contains=beanAmount contained
@@ -86,3 +86,4 @@ highlight default link beanPrice Number
 highlight default link beanTag Comment
 highlight default link beanLink Comment
 highlight default link beanMeta Comment
+highlight default link beanFlag Keyword


### PR DESCRIPTION
Beancount allows to attach flags to transactions and even to the postings themselves. At the moment it supports 12 different flags. Full list can be found in [Beancount sources](https://bitbucket.org/blais/beancount/src/tip/src/python/beancount/parser/lexer.l?fileviewer=file-view-default#lexer.l-199)

The PR updates syntax highlighting and AlignCommodity function to respect all flags.

P.S. I am not sure if there is a way to avoid duplication of the flag list.