### PR TITLE
Add python3 support

### DIFF
--- a/autoload/beancount.vim
+++ b/autoload/beancount.vim
@@ -72,9 +72,9 @@ function! beancount#complete(findstart, base)
         endif
     endif
 
-    let l:partial_line = strpart(getline("."), 0, getpos(".")[2])
+    let l:partial_line = strpart(getline("."), 0, getpos(".")[2]-1)
     " Match directive types
-    if l:partial_line =~# '^\d\d\d\d\(-\|/\)\d\d\1\d\d \S*$'
+    if l:partial_line =~# '^\d\d\d\d\(-\|/\)\d\d\1\d\d $'
         return beancount#complete_basic(s:directives, a:base, '')
     endif
 

--- a/autoload/beancount.vim
+++ b/autoload/beancount.vim
@@ -121,7 +121,7 @@ function! s:get_root()
 endfunction
 
 function! beancount#load_everything()
-    if s:using_python3
+    if s:using_python3 && !exists('b:beancount_loaded')
         let l:root = s:get_root()
 python3 << EOF
 import vim
@@ -159,6 +159,7 @@ vim.command('let b:beancount_events = [{}]'.format(','.join(repr(x) for x in sor
 vim.command('let b:beancount_links = [{}]'.format(','.join(repr(x) for x in sorted(links))))
 vim.command('let b:beancount_payees = [{}]'.format(','.join(repr(x) for x in sorted(payees))))
 vim.command('let b:beancount_tags = [{}]'.format(','.join(repr(x) for x in sorted(tags))))
+vim.command('let b:beancount_loaded = v:true'.format(','.join(repr(x) for x in sorted(tags))))
 EOF
     endif
 endfunction

--- a/autoload/beancount.vim
+++ b/autoload/beancount.vim
@@ -174,7 +174,6 @@ import os
 
 # We intentionally want to ignore stderr so it doesn't mess up our query processing
 output = subprocess.check_output(['bean-query', vim.eval('a:root_file'), vim.eval('a:query')], stderr=open(os.devnull, 'w')).split('\n')
-print(output)
 output = output[2:]
 
 result_list = [y for y in (x.strip() for x in output) if y]


### PR DESCRIPTION
This support also includes a new matching entity: event types.  Event types aren't accessible with bean-query, so we need full api access for this one.

It should also make all matching faster because we make fewer passes through the beancount file (especially for different type matches).  I'd really like to figure out a way to load the data in the background, but that may have to wait till vim 8... ;)