### PR TITLE
add back support for `*` transaction flag

### DIFF
--- a/syntax/beancount.vim
+++ b/syntax/beancount.vim
@@ -19,7 +19,7 @@ syn match beanCurrency "\v\w+" contained
 syn match beanAccount "\v[[:alnum:]]+:[-[:alnum:]:]+" contained
 syn match beanTag "\v#[-[:alnum:]]+" contained
 syn match beanLink "\v\^\S+" contained
-syn match beanFlag "\v[!&#?%PSTCURM]" contained
+syn match beanFlag "\v[*!&#?%PSTCURM]" contained
 
 " Most directives start with a date.
 syn match beanDate "^\v\d{4}[-/]\d{2}[-/]\d{2}" skipwhite
@@ -51,7 +51,7 @@ syn region beanPushTag matchgroup=beanKeyword start="\v^(push|pop)tag" end="$"
 syn region beanPad matchgroup=beanKeyword start="pad" end="$" contained
             \ keepend contains=beanAccount,beanComment
 
-syn region beanTxn matchgroup=beanKeyword start="\v\s+(txn|[!&#?%PSTCURM])" skip="^\s"
+syn region beanTxn matchgroup=beanKeyword start="\v\s+(txn|[*!&#?%PSTCURM])" skip="^\s"
             \ end="^" keepend contained fold
             \ contains=beanString,beanPost,beanComment,beanTag,beanLink,beanMeta
 syn region beanPost start="^\v\C\s+(([!&#?%PSTCURM]\s+)?[A-Z])@=" end="$"


### PR DESCRIPTION
It was mistakenly removed in #26.