### PR TITLE
Add an option to disable folding

### DIFF
--- a/ftplugin/beancount.vim
+++ b/ftplugin/beancount.vim
@@ -7,7 +7,10 @@ endif
 let b:did_ftplugin = 1
 let b:undo_ftplugin = "setlocal foldmethod< comments< commentstring<"
 
-setl foldmethod=syntax
+if !get(g:, "vim_beancount_folding_disabled", 0)
+    setl foldmethod=syntax
+endif
+
 setl comments=b:;
 setl commentstring=;%s
 compiler beancount


### PR DESCRIPTION
vim-markdown [provides an option to disable folding][vim-markdown]:

    let g:vim_markdown_folding_disabled = 1

Mirror that implementation to give vim-beancount users the same choice.

[vim-markdown]: https://github.com/plasticboy/vim-markdown/blob/a3169545f330ec8080244c3ad755bb2211eca8a0/after/ftplugin/markdown.vim#L150-L156