### PR TITLE
Fixes and lint

### DIFF
--- a/autoload/beancount.vim
+++ b/autoload/beancount.vim
@@ -2,12 +2,12 @@ let s:using_python3 = has('python3')
 
 " Equivalent to python's startswith
 " Matches based on user's ignorecase preference
-function! s:startswith(string, prefix)
+function! s:startswith(string, prefix) abort
     return strpart(a:string, 0, strlen(a:prefix)) == a:prefix
 endfunction
 
 " Align currency on decimal point.
-function! beancount#align_commodity(line1, line2)
+function! beancount#align_commodity(line1, line2) abort
     " Save cursor position to adjust it if necessary.
     let l:cursor_col = col('.')
     let l:cursor_line = line('.')
@@ -52,11 +52,11 @@ function! beancount#align_commodity(line1, line2)
     endwhile
 endfunction
 
-function! s:count_expression(text, expression)
+function! s:count_expression(text, expression) abort
     return len(split(a:text, a:expression, 1)) - 1
 endfunction
 
-function! s:sort_accounts_by_depth(name1, name2)
+function! s:sort_accounts_by_depth(name1, name2) abort
     let l:depth1 = s:count_expression(a:name1, ':')
     let l:depth2 = s:count_expression(a:name2, ':')
     return l:depth1 == l:depth2 ? 0 : l:depth1 > l:depth2 ? 1 : -1
@@ -67,7 +67,7 @@ let s:directives = ['open', 'close', 'commodity', 'txn', 'balance', 'pad', 'note
 " ------------------------------
 " Completion functions
 " ------------------------------
-function! beancount#complete(findstart, base)
+function! beancount#complete(findstart, base) abort
     if a:findstart
         let l:col = searchpos('\s', 'bn', line('.'))[1]
         if l:col == 0
@@ -118,14 +118,14 @@ function! beancount#complete(findstart, base)
     endif
 endfunction
 
-function! beancount#get_root()
+function! beancount#get_root() abort
     if exists('b:beancount_root')
         return b:beancount_root
     endif
     return expand('%')
 endfunction
 
-function! beancount#load_everything()
+function! beancount#load_everything() abort
     if s:using_python3 && !exists('b:beancount_loaded')
         let l:root = beancount#get_root()
 python3 << EOF
@@ -169,35 +169,35 @@ EOF
     endif
 endfunction
 
-function! beancount#load_accounts()
+function! beancount#load_accounts() abort
     if !s:using_python3 && !exists('b:beancount_accounts')
         let l:root = beancount#get_root()
         let b:beancount_accounts = beancount#query_single(l:root, 'select distinct account;')
     endif
 endfunction
 
-function! beancount#load_tags()
+function! beancount#load_tags() abort
     if !s:using_python3 && !exists('b:beancount_tags')
         let l:root = beancount#get_root()
         let b:beancount_tags = beancount#query_single(l:root, 'select distinct tags;')
     endif
 endfunction
 
-function! beancount#load_links()
+function! beancount#load_links() abort
     if !s:using_python3 && !exists('b:beancount_links')
         let l:root = beancount#get_root()
         let b:beancount_links = beancount#query_single(l:root, 'select distinct links;')
     endif
 endfunction
 
-function! beancount#load_currencies()
+function! beancount#load_currencies() abort
     if !s:using_python3 && !exists('b:beancount_currencies')
         let l:root = beancount#get_root()
         let b:beancount_currencies = beancount#query_single(l:root, 'select distinct currency;')
     endif
 endfunction
 
-function! beancount#load_payees()
+function! beancount#load_payees() abort
     if !s:using_python3 && !exists('b:beancount_payees')
         let l:root = beancount#get_root()
         let b:beancount_payees = beancount#query_single(l:root, 'select distinct payee;')
@@ -205,14 +205,14 @@ function! beancount#load_payees()
 endfunction
 
 " General completion function
-function! beancount#complete_basic(input, base, prefix)
+function! beancount#complete_basic(input, base, prefix) abort
     let l:matches = filter(copy(a:input), 's:startswith(v:val, a:base)')
 
     return map(l:matches, 'a:prefix . v:val')
 endfunction
 
 " Complete account name.
-function! beancount#complete_account(base)
+function! beancount#complete_account(base) abort
     if g:beancount_account_completion ==? 'chunks'
         let l:pattern = '^\V' . substitute(a:base, ':', '\\[^:]\\*:', 'g') . '\[^:]\*'
     else
@@ -234,7 +234,7 @@ function! beancount#complete_account(base)
     return l:matches
 endfunction
 
-function! beancount#query_single(root_file, query)
+function! beancount#query_single(root_file, query) abort
 python << EOF
 import vim
 import subprocess
@@ -251,7 +251,7 @@ EOF
 endfunction
 
 " Call bean-doctor on the current line and dump output into a scratch buffer
-function! beancount#get_context()
+function! beancount#get_context() abort
     let l:context = system('bean-doctor context ' . expand('%') . ' ' . line('.'))
     botright new
     setlocal buftype=nofile bufhidden=hide noswapfile

--- a/autoload/beancount.vim
+++ b/autoload/beancount.vim
@@ -9,33 +9,33 @@ endfunction
 " Align currency on decimal point.
 function! beancount#align_commodity(line1, line2)
     " Saving cursor position to adjust it if necessary.
-    let cursor_col = col('.')
-    let cursor_line = line('.')
+    let l:cursor_col = col('.')
+    let l:cursor_line = line('.')
 
     " This lets me increment at start of loop, because of continue statements.
-    let i = a:line1 - 1
-    while i < a:line2
-        let i += 1
-        let s = getline(i)
+    let l:current_line = a:line1 - 1
+    while l:current_line < a:line2
+        let l:current_line += 1
+        let l:line = getline(l:current_line)
         " This matches an account name followed by a space. There may be
         " some conflicts with non-transaction syntax that I don't know about.
         " It won't match a comment or any non-indented line.
-        let end_acc = matchend(s, '^\v(([\-/[:digit:]]+\s+(balance|price))|\s+[!&#?%PSTCURM])?\s+\S+[^:] ')
-        if end_acc < 0 | continue | endif
+        let l:end_acc = matchend(l:line, '^\v(([\-/[:digit:]]+\s+(balance|price))|\s+[!&#?%PSTCURM])?\s+\S+[^:] ')
+        if l:end_acc < 0 | continue | endif
         " Where does commodity amount begin?
-        let end_space = matchend(s, '^ *', end_acc)
+        let l:end_space = matchend(l:line, '^ *', l:end_acc)
 
         " Now look for a minus sign and a number, and align on the next column.
-        let l:comma = g:beancount_decimal_separator == ',' ? '.' : ','
-        let separator = matchend(s, '^\v(-)?[' . l:comma . '[:digit:]]+', end_space) + 1
-        if separator < 0 | continue | endif
-        let has_spaces = end_space - end_acc
-        let need_spaces = g:beancount_separator_col - separator + has_spaces
-        if need_spaces < 0 | continue | endif
-        call setline(i, s[0 : end_acc - 1] . repeat(" ", need_spaces) . s[ end_space : -1])
-        if i == cursor_line && cursor_col >= end_acc
+        let l:comma = g:beancount_decimal_separator ==# ',' ? '.' : ','
+        let l:separator = matchend(l:line, '^\v(-)?[' . l:comma . '[:digit:]]+', l:end_space) + 1
+        if l:separator < 0 | continue | endif
+        let l:has_spaces = l:end_space - l:end_acc
+        let l:need_spaces = g:beancount_separator_col - l:separator + l:has_spaces
+        if l:need_spaces < 0 | continue | endif
+        call setline(l:current_line, l:line[0 : l:end_acc - 1] . repeat(' ', l:need_spaces) . l:line[ l:end_space : -1])
+        if l:current_line == l:cursor_line && l:cursor_col >= l:end_acc
             " Adjust cursor position for continuity.
-            call cursor(0, cursor_col + need_spaces - has_spaces)
+            call cursor(0, l:cursor_col + l:need_spaces - l:has_spaces)
         endif
     endwhile
 endfunction

--- a/compiler/beancount.vim
+++ b/compiler/beancount.vim
@@ -1,19 +1,19 @@
-if exists("current_compiler")
+if exists('g:current_compiler')
     finish
 endif
-let current_compiler = "beancount"
+let g:current_compiler = 'beancount'
 
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
+if exists(':CompilerSet') != 2		" older Vim always used :setlocal
   command -nargs=* CompilerSet setlocal <args>
 endif
 
-let s:cpo_save = &cpo
-set cpo-=C
+let s:cpo_save = &cpoptions
+set cpoptions-=C
 
 CompilerSet makeprg=bean-check\ %
 CompilerSet errorformat=%-G         " Skip blank lines
 CompilerSet errorformat+=%f:%l:\ %m  " File:line: message
 CompilerSet errorformat+=%-G\ %.%#   " Skip indented lines.
 
-let &cpo = s:cpo_save
+let &cpoptions = s:cpo_save
 unlet s:cpo_save

--- a/doc/beancount.txt
+++ b/doc/beancount.txt
@@ -34,15 +34,14 @@ COMMANDS                                              *beancount-commands*
                     will be pushed to the right the appropriate amount, so
                     that it remains on the same character.
 
-                    The alignment character can be set using
-                    |g:beancount_decimal_separator|.  The script assumes the
-                    use of spaces for alignment. It does not understand tabs.
+                    The script assumes the use of spaces for alignment. It
+                    does not understand tabs.
 
                     You can use the following insert-mode remap to
                     automatically align commodities every time you type a
                     decimal point: >
 
-                        inoremap . .<C-O>:AlignCommodity<CR>
+                        inoremap . .<C-\><C-O>:AlignCommodity<CR>
 <
                     You may also want to set other mappings for this. For
                     example, I use >
@@ -78,11 +77,6 @@ OPTIONS                                              *beancount-options*
   The column that the decimal separator is aligned to.
 
   Default value: 50
-
-*g:beancount_decimal_separator*
-  Set the decimal separator that numbers are aligned by.
-
-  Default value: '.'
 
 *b:beancount_root*
   Set the root Beancount file. This is used to gather values for the

--- a/ftplugin/beancount.vim
+++ b/ftplugin/beancount.vim
@@ -1,28 +1,27 @@
-" These two variables customize the behavior of the AlignCommodity command.
-
-if exists("b:did_ftplugin")
-  finish
+if exists('b:did_ftplugin')
+    finish
 endif
 
 let b:did_ftplugin = 1
-let b:undo_ftplugin = "setlocal foldmethod< comments< commentstring<"
+let b:undo_ftplugin = 'setlocal foldmethod< comments< commentstring<'
 
 setl foldmethod=syntax
 setl comments=b:;
 setl commentstring=;%s
 compiler beancount
 
-if !exists("g:beancount_separator_col")
+" These two variables customize the behavior of the AlignCommodity command.
+if !exists('g:beancount_separator_col')
     let g:beancount_separator_col = 50
 endif
-if !exists("g:beancount_decimal_separator")
-    let g:beancount_decimal_separator = "."
+if !exists('g:beancount_decimal_separator')
+    let g:beancount_decimal_separator = '.'
 endif
 if !exists('g:beancount_account_completion')
-  let g:beancount_account_completion = 'default'
+    let g:beancount_account_completion = 'default'
 endif
 if !exists('g:beancount_detailed_first')
-  let g:beancount_detailed_first = 0
+    let g:beancount_detailed_first = 0
 endif
 
 command! -buffer -range AlignCommodity

--- a/ftplugin/beancount.vim
+++ b/ftplugin/beancount.vim
@@ -10,12 +10,9 @@ setl comments=b:;
 setl commentstring=;%s
 compiler beancount
 
-" These two variables customize the behavior of the AlignCommodity command.
+" This variable customizes the behavior of the AlignCommodity command.
 if !exists('g:beancount_separator_col')
     let g:beancount_separator_col = 50
-endif
-if !exists('g:beancount_decimal_separator')
-    let g:beancount_decimal_separator = '.'
 endif
 if !exists('g:beancount_account_completion')
     let g:beancount_account_completion = 'default'

--- a/indent/beancount.vim
+++ b/indent/beancount.vim
@@ -1,44 +1,44 @@
-if exists("b:did_indent")
+if exists('b:did_indent')
     finish
 endif
 let b:did_indent = 1
 
 setlocal indentexpr=GetBeancountIndent(v:lnum)
 
-if exists("*GetBeancountIndent")
+if exists('*GetBeancountIndent')
     finish
 endif
 
 function! s:IsDirective(str)
-    return a:str =~ '\v^\s*(\d{4}-\d{2}-\d{2}|pushtag|poptag|option|plugin|include)'
+    return a:str =~# '\v^\s*(\d{4}-\d{2}-\d{2}|pushtag|poptag|option|plugin|include)'
 endfunction
 
-function! s:IsPost(str)
-    return a:str =~ '\v^\s*(Assets|Liabilities|Expenses|Equity|Income):'
+function! s:IsPosting(str)
+    return a:str =~# '\v^\s*[A-Z]\w+:'
 endfunction
 
 function! s:IsMetadata(str)
-    return a:str =~ '\v^\s*\w+:\s'
+    return a:str =~# '\v^\s*[a-z][a-zA-Z0-9\-_]+:'
 endfunction
 
 function! s:IsTransaction(str)
     " The final \S represents the flag (e.g. * or !).
-    return a:str =~ '\v^\s*\d{4}-\d{2}-\d{2}\s+(txn\s+)?\S(\s|$)'
+    return a:str =~# '\v^\s*\d{4}-\d{2}-\d{2}\s+(txn\s+)?\S(\s|$)'
 endfunction
 
 function GetBeancountIndent(line_num)
-    let this_line = getline(a:line_num)
-    let prev_line = getline(a:line_num - 1)
+    let l:this_line = getline(a:line_num)
+    let l:prev_line = getline(a:line_num - 1)
     " Don't touch comments
-    if this_line =~ '\v^\s*;' | return -1 | endif
+    if l:this_line =~# '\v^\s*;' | return -1 | endif
     " This is a new directive or previous line is blank.
-    if prev_line =~ '^\s*$' || s:IsDirective(this_line) | return 0 | endif
+    if l:prev_line =~# '^\s*$' || s:IsDirective(l:this_line) | return 0 | endif
     " Previous line is transaction or this is a posting.
-    if s:IsTransaction(prev_line) || s:IsPost(this_line) | return &sw | endif
-    if s:IsMetadata(this_line)
-        let this_indent = indent(a:line_num - 1)
-        if ! s:IsMetadata(prev_line) | let this_indent += &sw | endif
-        return this_indent
+    if s:IsTransaction(l:prev_line) || s:IsPosting(l:this_line) | return &shiftwidth | endif
+    if s:IsMetadata(l:this_line)
+        let l:this_indent = indent(a:line_num - 1)
+        if ! s:IsMetadata(l:prev_line) | let l:this_indent += &shiftwidth | endif
+        return l:this_indent
     endif
     return -1
 endfunction

--- a/syntax_checkers/beancount/bean_check.vim
+++ b/syntax_checkers/beancount/bean_check.vim
@@ -4,17 +4,16 @@ endif
 
 let g:loaded_syntastic_beancount_bean_check=1
 
-let s:save_cpo = &cpo
-set cpo&vim
+let s:save_cpo = &cpoptions
+set cpoptions&vim
 
 function! SyntaxCheckers_beancount_bean_check_IsAvailable() dict
-    return executable(self.getExec())
+    return executable(l:self.getExec())
 endfunction
 
 function! SyntaxCheckers_beancount_bean_check_GetLocList() dict
-    let makeprg = self.makeprgBuild({})
-
-    return SyntasticMake({ 'makeprg': makeprg })
+    let l:makeprg = l:self.makeprgBuild({})
+    return SyntasticMake({ 'makeprg': l:makeprg })
 endfunction
 
 call g:SyntasticRegistry.CreateAndRegisterChecker({
@@ -22,5 +21,5 @@ call g:SyntasticRegistry.CreateAndRegisterChecker({
     \ 'name': 'bean_check',
     \ 'exec': 'bean-check'})
 
-let &cpo = s:save_cpo
+let &cpoptions = s:save_cpo
 unlet s:save_cpo


### PR DESCRIPTION
I ran [vint](https://github.com/Kuniwak/vint) on the codebase, which turned up some inconsistencies, the files I edited now all pass the linter. (It's mostly using settings-independent comparisons and always declaring scope for variables, which curiously helps with the syntax hightlighting of the source)

Also, I've removed the `g:beancount_decimal_separator` option. From the commit:

> Beancount only supports '.' as decimal separator so making the decimal
separator configurable doesn't serve any purpose and might confuse
users.

In addition, I've fixed the indent plugin for custom root accounts and fixed the suggested insert mode map in the documentation.