### PR TITLE
Tests; setup travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+matrix:
+  include:
+  - env: TEST_ENV=lint
+    language: python
+    before_script: pip install vim-vint
+    script: vint -s .
+  - env: TEST_ENV=test
+    language: viml
+    before_script: git clone https://github.com/junegunn/vader.vim.git
+    script: |
+      vim -Nu <(cat << VIMRC
+      set rtp+=vader.vim
+      set rtp+=.
+      filetype plugin indent on
+      VIMRC) -c 'Vader! test/*' > /dev/null

--- a/test/align.vader
+++ b/test/align.vader
@@ -1,7 +1,11 @@
 Given beancount:
+  2012-12-12 balance Assets:LongLongLongAccount 50.00
+  2012-12-12 balance Assets:Cash 50.00
+  2012-12-12 price EUR 50.00 USD
       metadata: 50
       Assets:Cash  50
       Assets:Cash  50.00
+      ! Assets:Cash  50.00
       Assets:Cash         50.00
       Assets:Cash         50.00 USD
 
@@ -9,9 +13,13 @@ Execute (align):
   %AlignCommodity
 
 Expect beancount:
+  2012-12-12 balance Assets:LongLongLongAccount  50.00
+  2012-12-12 balance Assets:Cash                 50.00
+  2012-12-12 price EUR                           50.00 USD
       metadata: 50
       Assets:Cash                                50
       Assets:Cash                                50.00
+      ! Assets:Cash                              50.00
       Assets:Cash                                50.00
       Assets:Cash                                50.00 USD
 
@@ -20,8 +28,12 @@ Execute (change alignment column and align again):
   %AlignCommodity
 
 Expect beancount:
+  2012-12-12 balance Assets:LongLongLongAccount 50.00
+  2012-12-12 balance Assets:Cash       50.00
+  2012-12-12 price EUR                 50.00 USD
       metadata: 50
       Assets:Cash                      50
       Assets:Cash                      50.00
+      ! Assets:Cash                    50.00
       Assets:Cash                      50.00
       Assets:Cash                      50.00 USD

--- a/test/align.vader
+++ b/test/align.vader
@@ -1,0 +1,27 @@
+Given beancount:
+      metadata: 50
+      Assets:Cash  50
+      Assets:Cash  50.00
+      Assets:Cash         50.00
+      Assets:Cash         50.00 USD
+
+Execute (align):
+  %AlignCommodity
+
+Expect beancount:
+      metadata: 50
+      Assets:Cash                                50
+      Assets:Cash                                50.00
+      Assets:Cash                                50.00
+      Assets:Cash                                50.00 USD
+
+Execute (change alignment column and align again):
+  let g:beancount_separator_col=40
+  %AlignCommodity
+
+Expect beancount:
+      metadata: 50
+      Assets:Cash                      50
+      Assets:Cash                      50.00
+      Assets:Cash                      50.00
+      Assets:Cash                      50.00 USD


### PR DESCRIPTION
[vader.vim](https://github.com/junegunn/vader.vim) provides a nice way to write tests for vimscript. I've added a basic test for the `beancount#align_commodity` function.

I've also added a config file for Travis which can run the tests and lint on every push and every PR. See the travis page of [my fork](https://travis-ci.org/yagebu/vim-beancount) for what this might look like. In particular, #39 merged with this PR merged [passes](https://travis-ci.org/yagebu/vim-beancount/builds/211178567) :)