### PR TITLE
Fix a regression bug in AlignCommodity

### DIFF
--- a/autoload/beancount.vim
+++ b/autoload/beancount.vim
@@ -39,7 +39,7 @@ function! beancount#align_commodity(line1, line2) abort
 
         " Look for a minus sign and a number (possibly containing commas) and
         " align on the next column.
-        let l:separator = matchend(l:line, '^\v(-)?[,[:digit:]]+', l:begin_number) + 1
+        let l:separator = matchend(l:line, '^\v([-+])?[,[:digit:]]+', l:begin_number) + 1
         if l:separator < 0 | continue | endif
         let l:has_spaces = l:begin_number - l:end_account
         let l:need_spaces = g:beancount_separator_col - l:separator + l:has_spaces

--- a/test/align.vader
+++ b/test/align.vader
@@ -1,6 +1,8 @@
 Given beancount:
   2012-12-12 balance Assets:LongLongLongAccount 50.00
   2012-12-12 balance Assets:Cash 50.00
+  2012-12-12 balance Assets:Cash -50.00
+  2012-12-12 balance Assets:Cash +50.00
   2012-12-12 price EUR 50.00 USD
       metadata: 50
       Assets:Cash  50
@@ -15,6 +17,8 @@ Execute (align):
 Expect beancount:
   2012-12-12 balance Assets:LongLongLongAccount  50.00
   2012-12-12 balance Assets:Cash                 50.00
+  2012-12-12 balance Assets:Cash                -50.00
+  2012-12-12 balance Assets:Cash                +50.00
   2012-12-12 price EUR                           50.00 USD
       metadata: 50
       Assets:Cash                                50
@@ -30,6 +34,8 @@ Execute (change alignment column and align again):
 Expect beancount:
   2012-12-12 balance Assets:LongLongLongAccount 50.00
   2012-12-12 balance Assets:Cash       50.00
+  2012-12-12 balance Assets:Cash      -50.00
+  2012-12-12 balance Assets:Cash      +50.00
   2012-12-12 price EUR                 50.00 USD
       metadata: 50
       Assets:Cash                      50


### PR DESCRIPTION
Since commit e17eb3d, putting a plus sign before a number causes
`:AlignCommodity` to behaviour incorrectly. A reproducible example:

```
Assets:Cash -100.00 USD
Expenses:Food +100.00 USD
```

This commit fixes the regression bug.