### PR TITLE
Speed up Vim exit

### DIFF
--- a/rplugin/python3/deoplete/sources/beancount.py
+++ b/rplugin/python3/deoplete/sources/beancount.py
@@ -36,9 +36,6 @@ class Source(Base):
         if context['event'] in ('Init', 'BufWritePost'):
             # Make cache on BufNewFile, BufRead, and BufWritePost
             self.__make_cache(context)
-        else:
-            # Do nothing on VimLeavePre
-            pass
 
     def get_complete_position(self, context):
         m = re.search(r'\S*$', context['input'])

--- a/rplugin/python3/deoplete/sources/beancount.py
+++ b/rplugin/python3/deoplete/sources/beancount.py
@@ -33,7 +33,12 @@ class Source(Base):
             self.error('Importing beancount failed.')
 
     def on_event(self, context):
-        self.__make_cache(context)
+        if context['event'] in ['Init', 'BufWritePost']:
+            # Make cache on BufNewFile, BufRead, and BufWritePost
+            self.__make_cache(context)
+        else:
+            # Do nothing on VimLeavePre
+            pass
 
     def get_complete_position(self, context):
         m = re.search(r'\S*$', context['input'])

--- a/rplugin/python3/deoplete/sources/beancount.py
+++ b/rplugin/python3/deoplete/sources/beancount.py
@@ -33,7 +33,7 @@ class Source(Base):
             self.error('Importing beancount failed.')
 
     def on_event(self, context):
-        if context['event'] in ['Init', 'BufWritePost']:
+        if context['event'] in ('Init', 'BufWritePost'):
             # Make cache on BufNewFile, BufRead, and BufWritePost
             self.__make_cache(context)
         else:


### PR DESCRIPTION
Making cache on every type of events makes exiting Vim quite slow. Per

https://github.com/Shougo/deoplete.nvim/blob/e6f4df0108081b8120df9ce83264e4997c4dfedc/doc/deoplete.txt#L891-L907

, only some types of events should be reacted to.