### PR TITLE
In the autocmd, set the filetype directly rather than using a function.

### DIFF
--- a/ftdetect/beancount.vim
+++ b/ftdetect/beancount.vim
@@ -5,4 +5,4 @@ function! s:setf(filetype) abort
     endif
 endfunction
 
-au BufNewFile,BufRead *.bean,*.beancount  call s:setf('beancount')
+au BufNewFile,BufRead *.bean,*.beancount set filetype=beancount


### PR DESCRIPTION
I think s:setf is a support function from vim-polyglot that is not part of the standard vim installation: https://github.com/sheerun/vim-polyglot/blob/fd74d8b2b170b540680a9bbf6c64990f8ebafd08/ftdetect/polyglot.vim#L853