### PR TITLE
Add ale fixer for beancount

### DIFF
--- a/autoload/ale/fixers/beanformat.vim
+++ b/autoload/ale/fixers/beanformat.vim
@@ -1,0 +1,12 @@
+call ale#Set('beancount_beanformat_executable', 'bean-format')
+call ale#Set('beancount_beanformat_options', '')
+
+function! ale#fixers#beanformat#Fix(buffer) abort
+    let l:executable = ale#Var(a:buffer, 'beancount_beanformat_executable')
+    let l:options = ale#Var(a:buffer, 'beancount_beanformat_options')
+    return {
+    \   'command': ale#Escape(l:executable)
+    \      . (empty(l:options) ? '' : ' ' . l:options)
+    \      . ' %t',
+    \}
+endfunction

--- a/ftplugin/beancount.vim
+++ b/ftplugin/beancount.vim
@@ -29,3 +29,7 @@ command! -buffer -range GetContext
 
 " Omnifunc for account completion.
 setl omnifunc=beancount#complete
+
+if exists('g:loaded_ale')
+  call ale#fix#registry#Add('bean-format', 'ale#fixers#beanformat#Fix', ['beancount'], 'bean-format')
+endif


### PR DESCRIPTION
This PR adds ALE fixer support for beancount files. It will invoke `bean-format` via ALE. User can automatically format their beancount files with ALE on saving.

It also adds two options `g:ale_beancount_beanformat_executable` and `g:ale_beancount_beanformat_options` for users to configure path to `bean-format` executable and options passed to the command.