### PR TITLE
Make ale linter configurable

### DIFF
--- a/ale_linters/beancount/bean_check.vim
+++ b/ale_linters/beancount/bean_check.vim
@@ -1,7 +1,22 @@
+call ale#Set('beancount_bean_check_executable', 'bean-check')
+call ale#Set('beancount_bean_check_options', '')
+
+function! ale_linters#beancount#bean_check#GetExecutable(buffer) abort
+    return ale#Var(a:buffer, 'beancount_bean_check_executable')
+endfunction
+
+function! ale_linters#beancount#bean_check#GetCommand(buffer) abort
+  let l:options = ale#Var(a:buffer, 'beancount_bean_check_options')
+  return ale#Escape(ale_linters#beancount#bean_check#GetExecutable(a:buffer))
+    \ . ' '
+    \ . (empty(l:options) ? '' : ' ' . l:options)
+    \ . ' %s'
+endfunction
+
 call ale#linter#Define('beancount', {
 \   'name': 'bean_check',
 \   'output_stream': 'stderr',
-\   'executable': 'bean-check',
-\   'command': 'bean-check %s',
+\   'executable_callback': 'ale_linters#beancount#bean_check#GetExecutable',
+\   'command_callback': 'ale_linters#beancount#bean_check#GetCommand',
 \   'callback': 'ale#handlers#unix#HandleAsError',
 \})


### PR DESCRIPTION
This pull request adds two options for configuring ALE beancount linter, `g:ale_beancount_bean_check_executable` and `g:ale_beancount_bean_check_options`.

The motivation of having this configurable is because I'm using multiple files in my beancount bookkeeping while the default `bean-check` won't check other files for account information. This ends up with many error messages "Invalid reference to unknown account". With the ability to configure the path to the executable, I'm able to write a bean-check wrapper to make it recognize my project structure. 