### PR TITLE
Fix regex matching in AlignCommodity

### DIFF
--- a/autoload/beancount.vim
+++ b/autoload/beancount.vim
@@ -25,10 +25,10 @@ function! beancount#align_commodity(line1, line2) abort
         "    by the 'balance' keyword and the account.
         "  - A price directive, i.e., the line starts with a date followed by
         "    the 'price' keyword and a currency.
-        let l:end_account = matchend(l:line, '^\v' .
-            \ '[\-/[:digit:]]+\s+balance\s+([A-Z][A-Za-z0-9\-]+)(:[A-Z][A-Za-z0-9\-]*)+ ' .
-            \ '|[\-/[:digit:]]+\s+price\s+\S+ ' .
-            \ '|\s+([!&#?%PSTCURM]\s+)?([A-Z][A-Za-z0-9\-]+)(:[A-Z][A-Za-z0-9\-]*)+ '
+        let l:end_account = matchend(l:line, '\v' .
+            \ '^[\-/[:digit:]]+\s+balance\s+([A-Z][A-Za-z0-9\-]+)(:[A-Z][A-Za-z0-9\-]*)+ ' .
+            \ '|^[\-/[:digit:]]+\s+price\s+\S+ ' .
+            \ '|^\s+([!&#?%PSTCURM]\s+)?([A-Z][A-Za-z0-9\-]+)(:[A-Z][A-Za-z0-9\-]*)+ '
             \ )
         if l:end_account < 0
             continue


### PR DESCRIPTION
The current regular expression only matches the start-of-line on the leftmost branch of the regular expression, leading to superfluous indents on lots of open statements when applying AlignCommodity to the entire file. Making this match explicit in every branch fixes the issue.