### PR TITLE
2x bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /doc/tags
+__pycache__

--- a/ale_linters/beancount/bean_check.vim
+++ b/ale_linters/beancount/bean_check.vim
@@ -2,6 +2,6 @@ call ale#linter#Define('beancount', {
 \   'name': 'bean_check',
 \   'output_stream': 'stderr',
 \   'executable': 'bean-check',
-\   'command': 'bean-check %s',
+\   'command': 'bean-check ' . beancount#get_root(),
 \   'callback': 'ale#handlers#unix#HandleAsError',
 \})

--- a/autoload/beancount.vim
+++ b/autoload/beancount.vim
@@ -26,9 +26,11 @@ function! beancount#align_commodity(line1, line2) abort
         "  - A price directive, i.e., the line starts with a date followed by
         "    the 'price' keyword and a currency.
         let l:end_account = matchend(l:line, '^\v' .
+            \ '(' .
             \ '[\-/[:digit:]]+\s+balance\s+([A-Z][A-Za-z0-9\-]+)(:[A-Z][A-Za-z0-9\-]*)+ ' .
             \ '|[\-/[:digit:]]+\s+price\s+\S+ ' .
-            \ '|\s+([!&#?%PSTCURM]\s+)?([A-Z][A-Za-z0-9\-]+)(:[A-Z][A-Za-z0-9\-]*)+ '
+            \ '|\s+([!&#?%PSTCURM]\s+)?([A-Z][A-Za-z0-9\-]+)(:[A-Z][A-Za-z0-9\-]*)+ ' .
+            \ ')'
             \ )
         if l:end_account < 0
             continue

--- a/autoload/beancount.vim
+++ b/autoload/beancount.vim
@@ -41,8 +41,9 @@ function! beancount#align_commodity(line1, line2) abort
 
         " Look for a minus sign and a number (possibly containing commas) and
         " align on the next column.
-        let l:separator = matchend(l:line, '^\v([-+])?[,[:digit:]]+', l:begin_number) + 1
+        let l:separator = matchend(l:line, '^\v([-+])?[,[:digit:]]+', l:begin_number)
         if l:separator < 0 | continue | endif
+        let l:separator = l:separator + 1
         let l:has_spaces = l:begin_number - l:end_account
         let l:need_spaces = g:beancount_separator_col - l:separator + l:has_spaces
         if l:need_spaces < 0 | continue | endif

--- a/test/align.vader
+++ b/test/align.vader
@@ -1,4 +1,5 @@
 Given beancount:
+  2012-12-11 open Assets:Cash USD
   2012-12-12 balance Assets:LongLongLongAccount 50.00
   2012-12-12 balance Assets:Cash 50.00
   2012-12-12 balance Assets:Cash -50.00
@@ -15,6 +16,7 @@ Execute (align):
   %AlignCommodity
 
 Expect beancount:
+  2012-12-11 open Assets:Cash USD
   2012-12-12 balance Assets:LongLongLongAccount  50.00
   2012-12-12 balance Assets:Cash                 50.00
   2012-12-12 balance Assets:Cash                -50.00
@@ -32,6 +34,7 @@ Execute (change alignment column and align again):
   %AlignCommodity
 
 Expect beancount:
+  2012-12-11 open Assets:Cash USD
   2012-12-12 balance Assets:LongLongLongAccount 50.00
   2012-12-12 balance Assets:Cash       50.00
   2012-12-12 balance Assets:Cash      -50.00

--- a/test/align.vader
+++ b/test/align.vader
@@ -46,3 +46,20 @@ Expect beancount:
       ! Assets:Cash                    50.00
       Assets:Cash                      50.00
       Assets:Cash                      50.00 USD
+
+Given beancount:
+  2000-01-01 open Assets:Cash USD
+  2000-01-01 open Expenses:Test USD
+  2012-12-12 * "test"
+    Assets:Cash 5.00 USD
+    Expenses:Test USD
+
+Execute (align with valid use of currency with no numeric value):
+  %AlignCommodity
+
+Expect beancount:
+  2000-01-01 open Assets:Cash USD
+  2000-01-01 open Expenses:Test USD
+  2012-12-12 * "test"
+    Assets:Cash                         5.00 USD
+    Expenses:Test USD


### PR DESCRIPTION
See the tests. Noticed because

```
2000-01-01 open Assets:Blah NZD
```

would be reformatted to

```
2000-01-01 open Assets:Blah <50 spaces> NZD
```

and then, if you ran `AlignCommodity` again, to 

```
2000-01-01 open Assets:Blah <50 spaces><50 spaces> NZD
```

and so on. It turns out there were two fixes:

- first commit: make sure this isn't run on `open` (as was intended, bug no group in regex meant it wasn't happening)
- second commit: handle the case where there's a currency and no numeric value. This seems to be a bug as the `continue` in [this line](https://github.com/nathangrigg/vim-beancount/blob/8054352c43168ece62094dfc8ec510e347e19e3c/autoload/beancount.vim#L43) could never run due to the `+ 1` in the previous line.