### PR TITLE
Make ALE use root beancount file 

### DIFF
--- a/ale_linters/beancount/bean_check.vim
+++ b/ale_linters/beancount/bean_check.vim
@@ -2,6 +2,6 @@ call ale#linter#Define('beancount', {
 \   'name': 'bean_check',
 \   'output_stream': 'stderr',
 \   'executable': 'bean-check',
-\   'command': 'bean-check %s',
+\   'command': 'bean-check '. beancount#get_root(),
 \   'callback': 'ale#handlers#unix#HandleAsError',
 \})


### PR DESCRIPTION
Updated the bean_check.vim to use the root beancount file based on user's setting