### PR TITLE
Update balance and posting regex to allow leading digits

### DIFF
--- a/autoload/beancount.vim
+++ b/autoload/beancount.vim
@@ -26,9 +26,9 @@ function! beancount#align_commodity(line1, line2) abort
         "  - A price directive, i.e., the line starts with a date followed by
         "    the 'price' keyword and a currency.
         let l:end_account = matchend(l:line, '^\v' .
-            \ '[\-/[:digit:]]+\s+balance\s+([A-Z][A-Za-z0-9\-]+)(:[A-Z][A-Za-z0-9\-]*)+ ' .
+            \ '[\-/[:digit:]]+\s+balance\s+([A-Z][A-Za-z0-9\-]+)(:[A-Z0-9][A-Za-z0-9\-]*)+ ' .
             \ '|[\-/[:digit:]]+\s+price\s+\S+ ' .
-            \ '|\s+([!&#?%PSTCURM]\s+)?([A-Z][A-Za-z0-9\-]+)(:[A-Z][A-Za-z0-9\-]*)+ '
+            \ '|\s+([!&#?%PSTCURM]\s+)?([A-Z][A-Za-z0-9\-]+)(:[A-Z0-9][A-Za-z0-9\-]*)+ '
             \ )
         if l:end_account < 0
             continue


### PR DESCRIPTION
The beancount documentation around what makes an allowable "Account name" is subtle, and has been very slightly misinterpreted here in vim-beancount.

Here's what the doc (https://beancount.github.io/docs/beancount_language_syntax.html#accounts) says:

"An account name is a colon-separated list of capitalized words which begin with a letter, and whose first word must be one of five account types (Assets Liabilities Equity Income Expenses). Each component of the account names begin with a capital letter or a number and are followed by letters, numbers or dash (-) characters. All other characters are disallowed."

This has been interpreted here that the leading character of each *component* must be a capital letter, whereas actually the 2nd, and later, components may start with a number.

As can be seen in the actual beancount/v2 code (https://github.com/beancount/beancount/blob/v2/beancount/core/account.py#L28), the "first character must be upper case" requirement is *only* true of the first/root account name component, which is limited to Assets/Liabilities/Equity/Income/Expenses, so that's true regardless.

This might seem like a minor thing, but vim-beancount's current regex stops auto-alignment of useful account names such as:

```
Assets:ISA:2020-2021
Expenses:Groceries:2019-2020
```

In other words, forcing the use of workarounds like "...:Y2020-2021". Well, "forcing" if one wants to get consistent automatic alignment across an entire file :-)

This commit marries up the vim-beancount regex with the beancount/v2 implementation at https://github.com/beancount/beancount/blob/v2/beancount/core/account.py#L28.